### PR TITLE
Ignore new entrypoints when using old versions of the driver

### DIFF
--- a/nifpga/tests/test_nifpga.py
+++ b/nifpga/tests/test_nifpga.py
@@ -182,6 +182,33 @@ class StatusCheckedLibraryTestCRunTime(unittest.TestCase):
                 self.assertIn("nptr: b'1'", str(warning))
 
 
+class StatusCheckedLibraryTestFunctionDoesntExist(unittest.TestCase):
+    """
+    New versions of NiFpga will have new functions.  We want the API to support
+    old versions of NiFpga without erroring because it can't find certain symbols.
+    So StatusCheckedLibrary will return FeatureNotSupported for symbols it can't
+    find.
+    """
+    def setUp(self):
+        self._c_runtime = StatusCheckedLibrary(
+            "c",
+            library_function_infos=[
+                LibraryFunctionInfo(
+                    pretty_name="DoesntExist",
+                    name_in_library="functionThatDoesntExist",
+                    named_argtypes=[
+                        NamedArgtype("nptr", ctypes.c_char_p),
+                    ])
+            ])
+
+    def test_correct_error(self):
+        with self.assertRaises(nifpga.VersionMismatchError):
+            self._c_runtime.DoesntExist(b"0")
+        with self.assertRaises(nifpga.VersionMismatchError):
+            self._c_runtime["DoesntExist"](b"0")
+
+
+
 class StatusCheckedLibraryTestMockedLibrary(unittest.TestCase):
     """
     Since we can't load NiFpga on a dev machine unless we have all its

--- a/nifpga/tests/test_nifpga.py
+++ b/nifpga/tests/test_nifpga.py
@@ -208,7 +208,6 @@ class StatusCheckedLibraryTestFunctionDoesntExist(unittest.TestCase):
             self._c_runtime["DoesntExist"](b"0")
 
 
-
 class StatusCheckedLibraryTestMockedLibrary(unittest.TestCase):
     """
     Since we can't load NiFpga on a dev machine unless we have all its


### PR DESCRIPTION
Allow the Python API to work with existing versions of the driver as we
add new entrypoints to the API.  New functions throw a Version Mismatch
error if used on a driver that doesn't support them.