### PR TITLE
Ignoring FXP types with incomplete metadata

### DIFF
--- a/nifpga/bitfile.py
+++ b/nifpga/bitfile.py
@@ -381,7 +381,12 @@ class _FXP(_BaseType):
     def __init__(self, name, type_xml):
         super(_FXP, self).__init__(name)
         self._datatype = DataType.Fxp
-        self._signed = True if type_xml.find("Signed").text.lower() == 'true' else False
+        signed_tag = type_xml.find("Signed")
+        if signed_tag is None:
+            raise UnsupportedTypeError("Unsupported FXP type encountered. This bitfile "
+                                       "was likely compiled with LabVIEW Communications 2.0. "
+                                       "Recompile with LabVIEW Communications 2.1 or later.")
+        self._signed = True if signed_tag.text.lower() == 'true' else False
         overflow_enabled_xml = type_xml.find("IncludeOverflowStatus")
         if overflow_enabled_xml is not None:
             self._overflow_enabled = True if overflow_enabled_xml.text.lower() == 'true' else False

--- a/nifpga/tests/allregistertypes.lvbitx
+++ b/nifpga/tests/allregistertypes.lvbitx
@@ -1874,6 +1874,31 @@
 				    <SubControlList/>
 			</Register>
 			  <Register>
+				    <Name>Comms 2.0 FXP</Name>
+				    <Hidden>false</Hidden>
+				    <Indicator>true</Indicator>
+				    <Datatype>
+					    <FXP>
+						      <Name>Comms 2.0 FXP</Name>
+					</FXP>
+				</Datatype>
+				    <FlattenedType>13008000000000010058405F0311003F00000020000000010000000100000000000000000000003F000000207FFFFFFFFFFFFFFF00000001FFFFFFE200000000000000011A4F7574707574204658502036332D62697420556E7369676E65640000010000000000000000000000000000</FlattenedType>
+				    <Grouping/>
+				    <Offset>98556</Offset>
+				    <SizeInBits>63</SizeInBits>
+				    <Class>18</Class>
+				    <Internal>false</Internal>
+				    <TypedefPath/>
+				    <TypedefRelativePath/>
+				    <ID>63</ID>
+				    <Bidirectional>true</Bidirectional>
+				    <Synchronous>false</Synchronous>
+				    <MechanicalAction>Switch When Pressed</MechanicalAction>
+				    <AccessMayTimeout>false</AccessMayTimeout>
+				    <RegisterNode>false</RegisterNode>
+				    <SubControlList/>
+			</Register>
+			  <Register>
 				    <Name>Output FXP 63-bit Signed</Name>
 				    <Hidden>false</Hidden>
 				    <Indicator>true</Indicator>


### PR DESCRIPTION
LabVIEW Communications 2.0 shipped with an issue where it doesn't output all of the XML required for FXP types.  The Python API will now skip a register or FIFO that doesn't contain all of the needed metadata.

Resolves #25 