### PR TITLE
Specifying long_description_content_type

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ def get_long_description():
 setup(name="nifpga",
       description="Python API for interacting with National Instrument's LabVIEW FPGA Devices",
       long_description=get_long_description(),
+      long_description_content_type="text/markdown",
       version=get_version(),
       packages=find_packages(),
       install_requires=['enum34;python_version<"3.4"', 'future'],


### PR DESCRIPTION
I was wondering why our description never showed up correctly on pypi.

Uploading to pypi errored telling me to specify this.