### PR TITLE
Fixing warning in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 FPGA Interface Python API
-=======
+=========================
 
 [![Build Status](https://travis-ci.org/ni/nifpga-python.svg?branch=master)](https://travis-ci.org/ni/nifpga-python)
 


### PR DESCRIPTION
twine check said "Warning: Title underline too short."