### PR TITLE
Add AddFifo function to nifpga.py

### DIFF
--- a/nifpga/nifpga.py
+++ b/nifpga/nifpga.py
@@ -295,6 +295,16 @@ class _NiFpga(StatusCheckedLibrary):
                     NamedArgtype("irqs", ctypes.c_uint32),
                 ]),
             LibraryFunctionInfo(
+                pretty_name="AddFifo",
+                name_in_library="NiFpgaDll_AddFifo",
+                named_argtypes=[
+                    NamedArgtype("session", _SessionType),
+                    NamedArgtype("fifo", ctypes.c_uint32),
+                    NamedArgtype("baseAddress", ctypes.c_uint32),
+                    NamedArgtype("direction", ctypes.c_uint32),
+                    NamedArgtype("bytesPerElement", ctypes.c_uint32),
+                ]),
+            LibraryFunctionInfo(
                 pretty_name="ConfigureFifo",
                 name_in_library="NiFpgaDll_ConfigureFifo",
                 named_argtypes=[


### PR DESCRIPTION
[x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nifpga-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Adding the new AddFifo function.  Going to add a fancier python API for it later.  This will unblock testing though.

### Why should this Pull Request be merged?

Matching with C API

### What testing has been done?

I'm able to call the function and my new internal tests pass.
